### PR TITLE
User can get one or all routines

### DIFF
--- a/app/controllers/api/v1/routines_controller.rb
+++ b/app/controllers/api/v1/routines_controller.rb
@@ -1,0 +1,9 @@
+class Api::V1::RoutinesController < ApplicationController
+  def index
+    render json: RoutineSerializer.new(Routine.all)
+  end
+
+  def show
+    render json: RoutineSerializer.new(Routine.find(params[:id]))
+  end
+end

--- a/app/serializers/routine_serializer.rb
+++ b/app/serializers/routine_serializer.rb
@@ -1,0 +1,4 @@
+class RoutineSerializer
+  include FastJsonapi::ObjectSerializer
+  attributes :name
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :exercises, only: [:index, :show]
+      resources :routines, only: [:index, :show]
     end
   end
 end

--- a/spec/requests/api/v1/routine_request_spec.rb
+++ b/spec/requests/api/v1/routine_request_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+describe 'Routines API' do
+  describe 'Endpoints' do
+    before :each do
+      @routine = Routine.create(name: 'Cardio Day')
+      Routine.create(name: 'Leg Day')
+      Routine.create(name: 'Arm Day')
+    end
+
+    it 'can get a list of routines' do
+      get '/api/v1/routines'
+
+      expect(response).to be_successful
+      routines = JSON.parse(response.body, symbolize_names: true)
+      expect(routines[:data].count).to eq(3)
+      expect(routines[:data]).to be_a(Array)
+      expect(routines[:data][0]).to be_a(Hash)
+      expect(routines[:data][0].keys).to include(:id)
+      expect(routines[:data][0].keys).to include(:type)
+      expect(routines[:data][0][:type]).to eq('routine')
+      expect(routines[:data][0][:attributes][:name]).to eq('Cardio Day')
+    end
+
+    it 'can get a single routine' do
+      get "/api/v1/routines/#{@routine.id}"
+
+      expect(response).to be_successful
+      routine = JSON.parse(response.body, symbolize_names: true)
+      expect(routine[:data]).to be_a(Hash)
+      expect(routine[:data][:id]).to eq(@routine.id.to_s)
+      expect(routine[:data][:type]).to eq('routine')
+      expect(routine[:data][:attributes][:name]).to eq('Cardio Day')
+    end
+  end
+end


### PR DESCRIPTION
## Changes Made:
- Added route for '/api/v1/routines' that gets all the routines in the database, as well as getting one
- Added RoutinesController, RoutineSerializer which converts Routines into Fast Json Standard JSON

### Testing complete?
- [x] Yes
- [ ] Not yet

### Final checklist:
- [x] My code has no unused/commented out code
- [x] I have reviewed my code
- [ ] I have commented my code, particularly in hard-to-understand areas